### PR TITLE
Fix System.UriFormatException on muliple server in NatsURL

### DIFF
--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -189,11 +189,9 @@ namespace STAN.Client
                 ncOwned = true;
                 try
                 {
-                    var nopts = ConnectionFactory.GetDefaultOptions();
-                    nopts.MaxReconnect = Options.ReconnectForever;
-                    nopts.Url = opts.NatsURL;
+                    nc = new ConnectionFactory().CreateConnection(opts.NatsURL);
+                    nc.Opts.MaxReconnect = Options.ReconnectForever;
                     // TODO:  disable buffering.
-                    nc = new ConnectionFactory().CreateConnection(nopts);
                 }
                 catch (Exception ex)
                 {

--- a/STAN.Client.UnitTests/UnitTestBasic.cs
+++ b/STAN.Client.UnitTests/UnitTestBasic.cs
@@ -2248,5 +2248,20 @@ namespace STAN.Client.UnitTests
             };
             sclh(this, clArgs);
         }
+        [Fact]
+        public void TestMultipleNatsUrl()
+        {
+
+            using (new NatsStreamingServer())
+            {
+                var opts = StanOptions.GetDefaultOptions();
+                opts.NatsURL = "nats://127.0.0.1:4222,nats://127.0.0.1:4222";
+                opts.ConnectTimeout = 5000;
+                using (var c = new StanConnectionFactory().CreateConnection(CLUSTER_ID, CLIENT_ID, opts))
+                {
+                    c.Close();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes the following exception if NatUrl contains multiple server

e.g.
var opts = StanOptions.GetDefaultOptions();
opts.NatsURL = "nats://127.0.0.1:4222,nats://127.0.0.1:4222";


Exception
 STAN.Client.StanConnectionException : Invalid connection.
[09/05/2019 19:22:36 Informational] [xUnit.net 00:00:02.0486549]       ---- System.UriFormatException : Invalid URI: Invalid port specified.
[09/05/2019 19:22:36 Informational] [xUnit.net 00:00:02.0497734]       Stack Trace:
[09/05/2019 19:22:36 Informational] [xUnit.net 00:00:02.0509682]         C:\dev\csharp-nats-streaming\STAN.CLIENT\StanConnection.cs(200,0): at STAN.Client.Connection..ctor(String stanClusterID, String clientID, StanOptions options)
[09/05/2019 19:22:36 Informational] [xUnit.net 00:00:02.0513004]         C:\dev\csharp-nats-streaming\STAN.CLIENT\StanConnectionFactory.cs(32,0): at STAN.Client.StanConnectionFactory.CreateConnection(String clusterID, String clientID, StanOptions options)