### PR TITLE
 Normalize casing of assemblies in NuGet package

### DIFF
--- a/STAN.CLIENT/Properties/AssemblyInfo.cs
+++ b/STAN.CLIENT/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("STAN.CLIENT")]
+[assembly: AssemblyTitle("STAN.Client")]
 [assembly: AssemblyDescription("NATS Streaming Client API")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("CNCF")]

--- a/STAN.CLIENT/STAN.CLIENT.csproj
+++ b/STAN.CLIENT/STAN.CLIENT.csproj
@@ -7,8 +7,8 @@
     <VersionPrefix>0.1.7</VersionPrefix>
     <TargetFramework>netstandard1.6</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>STAN.CLIENT</AssemblyName>
-    <PackageId>STAN.CLIENT</PackageId>
+    <AssemblyName>STAN.Client</AssemblyName>
+    <PackageId>STAN.Client</PackageId>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/net45/STAN.Client/STAN.Client.csproj
+++ b/net45/STAN.Client/STAN.Client.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>STAN.Client</RootNamespace>
-    <AssemblyName>STAN.CLIENT</AssemblyName>
+    <AssemblyName>STAN.Client</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <DocumentationFile>bin\Release\STAN.CLIENT.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\STAN.Client.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Google.Protobuf, Version=3.7.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">

--- a/nuget/STAN.Client.nuspec
+++ b/nuget/STAN.Client.nuspec
@@ -23,8 +23,8 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="lib\net45\STAN.Client.DLL" target="lib\net45\STAN.Client.DLL" />
-        <file src="lib\net45\STAN.Client.XML" target="lib\net45\STAN.Client.XML" />
+        <file src="lib\net45\STAN.Client.dll" target="lib\net45\STAN.Client.dll" />
+        <file src="lib\net45\STAN.Client.xml" target="lib\net45\STAN.Client.xml" />
         <file src="lib\netstandard1.6\STAN.Client.dll" target="lib\netstandard1.6\STAN.Client.dll" />
         <file src="lib\netstandard1.6\STAN.Client.xml" target="lib\netstandard1.6\STAN.Client.xml" />
         <file src="lib\netstandard1.6\STAN.Client.deps.json" target="lib\netstandard1.6\STAN.Client.deps.json" />                

--- a/nuget/STAN.Client.nuspec
+++ b/nuget/STAN.Client.nuspec
@@ -25,8 +25,8 @@
     <files>
         <file src="lib\net45\STAN.Client.DLL" target="lib\net45\STAN.Client.DLL" />
         <file src="lib\net45\STAN.Client.XML" target="lib\net45\STAN.Client.XML" />
-        <file src="lib\netstandard1.6\STAN.Client.DLL" target="lib\netstandard1.6\STAN.Client.DLL" />
-        <file src="lib\netstandard1.6\STAN.Client.XML" target="lib\netstandard1.6\STAN.Client.XML" />
+        <file src="lib\netstandard1.6\STAN.Client.dll" target="lib\netstandard1.6\STAN.Client.dll" />
+        <file src="lib\netstandard1.6\STAN.Client.xml" target="lib\netstandard1.6\STAN.Client.xml" />
         <file src="lib\netstandard1.6\STAN.Client.deps.json" target="lib\netstandard1.6\STAN.Client.deps.json" />                
     </files>
 </package>

--- a/nuget/build_pkg.bat
+++ b/nuget/build_pkg.bat
@@ -10,8 +10,8 @@ if errorlevel 9009 if not errorlevel 9010 (
     goto End
 )
 
-set STAN_CLIENT_45=..\net45\STAN.Client\bin\Release\STAN.Client.DLL
-set STAN_CLIENT_XML_45=..\net45\STAN.Client\bin\Release\STAN.Client.XML
+set STAN_CLIENT_45=..\net45\STAN.Client\bin\Release\STAN.Client.dll
+set STAN_CLIENT_XML_45=..\net45\STAN.Client\bin\Release\STAN.Client.xml
 set STAN_CORE_DIR=..\STAN.Client\bin\Release\netstandard1.6
 
 if NOT EXIST %STAN_CLIENT_45% (
@@ -39,7 +39,7 @@ copy %STAN_CLIENT_45% tmp\lib\net45 1>NUL
 copy %STAN_CLIENT_XML_45% tmp\lib\net45 1>NUL
 copy %STAN_CORE_DIR%\* tmp\lib\netstandard1.6 1>NUL
 
-REM (to recreate) nuget spec -f -Verbosity detailed -AssemblyPath STAN.Client.DLL
+REM (to recreate) nuget spec -f -Verbosity detailed -AssemblyPath STAN.Client.dll
 
 cd tmp
 


### PR DESCRIPTION
Make sure that casing is consistent within the NuGet package.
We got casing troubles from our case-sensitive deployment system.

This fixes https://github.com/nats-io/stan.net/issues/54.