### PR TITLE
Fix publish reconnect behavior

### DIFF
--- a/STAN.CLIENT/STANExceptions.cs
+++ b/STAN.CLIENT/STANExceptions.cs
@@ -101,12 +101,15 @@ namespace STAN.Client
 
     /// <summary>
     /// An exception representing the case when a connection cannot be established
-    /// with the NATS streaming server.
+    /// with the NATS streaming server or an operation is attempted while the underlying
+    /// NATS connection is reconnecting.
     /// </summary>
     public class StanConnectionException : StanException
     {
         internal StanConnectionException() : base("Invalid connection.") { }
         internal StanConnectionException(Exception e) : base("Invalid connection.", e) { }
+        internal StanConnectionException(string msg) : base(msg) { }
+
     }
 
     /// <summary>

--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -74,8 +74,10 @@ namespace STAN.Client
 
         private void ackTimerCb(object state)
         {
-            connection.removeAck(this.guidValue);
-            InvokeHandler(guidValue, "Timeout occurred.");
+            if (connection.removeAck(guidValue) != null)
+            {
+                InvokeHandler(guidValue, "Timeout occurred.");
+            }
         }
 
         internal void wait(int timeout)
@@ -86,14 +88,14 @@ namespace STAN.Client
                 {
                     Monitor.Wait(cond, timeout);
                 }
+                if (ex != null)
+                    throw ex;
             }
         }
 
         internal void wait()
         {
             wait(Timeout.Infinite);
-            if (ex != null)
-                throw ex;
         }
 
         internal void complete()
@@ -446,7 +448,7 @@ namespace STAN.Client
             var keys = pubAckMap.Keys;
             foreach (string guid in keys)
             {
-                if (pubAckMap.Remove(guid, out pa, 0))
+                if (pubAckMap.Remove(guid, out pa))
                 {
                     pa.InvokeHandler(guid, ex == null ? "Connection Closed." : ex.Message);
                 }
@@ -502,10 +504,11 @@ namespace STAN.Client
 
             lock (mu)
             {
-                pubAckMap.Remove(guid, out a, 0);
+                if (pubAckMap.Remove(guid, out a))
+                    return a;
             }
 
-            return a;
+            return null;
         }
 
         public IConnection NATSConnection
@@ -584,15 +587,18 @@ namespace STAN.Client
             string subj = this.pubPrefix + "." + subject;
             string guidValue = newGUID();
             byte[] b = ProtocolSerializer.createPubMsg(clientID, guidValue, subject, data, connID);
-
-            PublishAck a = new PublishAck(this, guidValue, handler, opts.PubAckWait);
+            PublishAck a = null;
 
             lock (mu)
             {
                 if (nc == null)
                     throw new StanConnectionClosedException();
 
-                while (!pubAckMap.TryAdd(guidValue, a))
+                if (nc.IsReconnecting())
+                    throw new StanConnectionException("The NATS connection is reconnecting");
+
+                a = new PublishAck(this, guidValue, handler, opts.PubAckWait);
+                while (!pubAckMap.TryAdd(guidValue,a))
                 {
                     var bd = pubAckMap;
 

--- a/STAN.Client.UnitTests/UnitTestUtilities.cs
+++ b/STAN.Client.UnitTests/UnitTestUtilities.cs
@@ -116,8 +116,8 @@ namespace STAN.Client.UnitTests
 
     class NatsServer : RunnableServer
     {
-        public NatsServer() : base("gnatsd") { }
-        public NatsServer(string args) : base("gnatsd", args) { }
+        public NatsServer() : base("nats-server") { }
+        public NatsServer(string args) : base("nats-server", args) { }
     }
 
     class NatsStreamingServer : RunnableServer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 install:
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-  - appveyor DownloadFile https://github.com/nats-io/nats-streaming-server/releases/download/v0.12.0/nats-streaming-server-v0.12.0-windows-amd64.zip
-  - appveyor DownloadFile https://github.com/nats-io/gnatsd/releases/download/v1.4.1/gnatsd-v1.4.1-windows-amd64.zip
-  - 7z e nats-streaming-server-v0.12.0-windows-amd64.zip nats-streaming-server.exe -r -oc:\projects\nss\build
-  - 7z e  gnatsd-v1.4.1-windows-amd64.zip gnatsd.exe -r -oc:\projects\nss\build
+  - appveyor DownloadFile https://github.com/nats-io/nats-streaming-server/releases/download/v0.16.0/nats-streaming-server-v0.16.0-windows-amd64.zip
+  - appveyor DownloadFile https://github.com/nats-io/nats-server/releases/download/v2.0.4/nats-server-v2.0.4-windows-amd64.zip 
+  - 7z e nats-streaming-server-v0.16.0-windows-amd64.zip nats-streaming-server.exe -r -oc:\projects\nss\build
+  - 7z e nats-server-v2.0.4-windows-amd64.zip nats-server.exe -r -oc:\projects\nss\build
   - cmd: set PATH=%PATH%;C:\projects\nss\build
-  - cmd: gnatsd -version
+  - cmd: nats-server -version
   - cmd: nats-streaming-server.exe -version
 
 # to add several configurations to build matrix:


### PR DESCRIPTION
Attempting a publish during reconnect could cause a loop in the publish ack processing resulting in high CPU utilization and deadlock behavior.

This PR does the following:
* Simplifies acknowledgment processing
* Prevents a timeout error for the case an acknowledgment has already been processed, removing a potential race condition.
* Fails fast to throw an exception if a publish is invoked while attempting to reconnect (the publish could never have succeeded).
* Adds tests to publish while reconnecting.
* Updates the server versions

Resolves #136 and #137