### PR TITLE
Do not disconnect on NATSReconnectBufferException

### DIFF
--- a/src/STAN.Client/Options.cs
+++ b/src/STAN.Client/Options.cs
@@ -80,9 +80,7 @@ namespace STAN.Client
         {
             set
             {
-                if(value != null && value.Opts.ReconnectBufferSize != Options.ReconnectBufferDisabled)
-                    throw new ArgumentException("The underlying NATS connection should have buffers during reconnect disabled. E.g controlled via: 'Opts.ReconnectBufferSize = Options.ReconnectBufferDisabled'", nameof(value));
-
+                // TODO:  Override NATS connection buffer settings.
                 natsConn = value;
             }
         }

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -380,8 +380,7 @@ namespace STAN.Client
             catch (Exception ex)
             when (
                 ex is NATSConnectionClosedException || 
-                ex is NATSStaleConnectionException ||
-                ex is NATSReconnectBufferException)
+                ex is NATSStaleConnectionException)
             {
                 closeDueToPing(ex);
             }

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -338,7 +338,6 @@ namespace STAN.Client
         private void pingServer(object state)
         {
             IConnection conn = null;
-            Exception pingEx = null;
             bool lostConnection = false;
 
             lock (pingLock)
@@ -358,7 +357,6 @@ namespace STAN.Client
                 if (pingOut > pingMaxOut)
                 {
                     lostConnection = true;
-                    pingEx = new StanMaxPingsException();
                 }
                 else
                 {
@@ -369,7 +367,7 @@ namespace STAN.Client
 
             if (lostConnection)
             {
-                closeDueToPing(pingEx);
+                closeDueToPing(new StanMaxPingsException());
                 return;
             }
             
@@ -384,6 +382,7 @@ namespace STAN.Client
             {
                 closeDueToPing(ex);
             }
+            catch { /* ignore other publish exceptions */ }
         }
 
         private void closeDueToPing(Exception ex)


### PR DESCRIPTION
Ignore the reconnect buffer exception when pinging to allow the connection to self heal.

Signed-off-by: Colin Sullivan <colin@synadia.com>