### PR TITLE
Fix close during reconnect

### DIFF
--- a/src/STAN.Client/Options.cs
+++ b/src/STAN.Client/Options.cs
@@ -80,9 +80,7 @@ namespace STAN.Client
         {
             set
             {
-                if(value != null && value.Opts.ReconnectBufferSize != Options.ReconnectBufferDisabled)
-                    throw new ArgumentException("The underlying NATS connection should have buffers during reconnect disabled. E.g controlled via: 'Opts.ReconnectBufferSize = Options.ReconnectBufferDisabled'", nameof(value));
-
+                // TODO:  Override NATS connection buffer settings.
                 natsConn = value;
             }
         }

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
  * \section install_sec Installation
  *
  * Instructions to build and install the %NATS .NET C# Streaming Client can be
- * found at the [NATS .NET C# Streaming Client GitHub page](https://github.com/nats-io/csharp-nats-streaming)
+ * found at the [NATS .NET C# Streaming Client GitHub page](https://github.com/nats-io/stan.net)
  *
  * \section other_doc_section Other Documentation
  *
@@ -36,9 +36,10 @@ using System.Threading.Tasks;
  * information, refer to the following:
  *
  * - [General Documentation for nats.io](http://nats.io/documentation)
- * - [NATS .NET C# Streaming Client found on GitHub](https://github.com/nats-io/csharp-nats-streaming)
- * - [NATS .NET C# Client found on GitHub](https://github.com/nats-io/csnats)
- * - [The NATS server (gnatsd) found on GitHub](https://github.com/nats-io/gnatsd)
+ * - [NATS .NET C# Streaming Client found on GitHub](https://github.com/nats-io/stan.net)
+ * - [NATS .NET C# Client found on GitHub](https://github.com/nats-io/nats.net)
+ * - [The NATS server (nats-server) found on GitHub](https://github.com/nats-io/nats-server)
+ * - [The NATS streaming server (nats-streaming-server) found on GitHub](https://github.com/nats-io/nats-streaming-server)
  */
 
 // disable XML comment warnings
@@ -793,6 +794,13 @@ namespace STAN.Client
                 {
                     // it's possible we never actually connected.
                     return;
+                }
+                catch (NATSReconnectBufferException)
+                {
+                    // In order to maintain backward compatibility, we need to avoid throwing
+                    // this exception.  The reply will be null, so we'll fall through
+                    // and gracefully close the streaming connection.  The streaming server
+                    // will cleanup this client on its own.
                 }
 
                 if (reply != null)

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -380,8 +380,7 @@ namespace STAN.Client
             catch (Exception ex)
             when (
                 ex is NATSConnectionClosedException || 
-                ex is NATSStaleConnectionException ||
-                ex is NATSReconnectBufferException)
+                ex is NATSStaleConnectionException)
             {
                 closeDueToPing(ex);
             }

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -338,7 +338,6 @@ namespace STAN.Client
         private void pingServer(object state)
         {
             IConnection conn = null;
-            Exception pingEx = null;
             bool lostConnection = false;
 
             lock (pingLock)
@@ -358,7 +357,6 @@ namespace STAN.Client
                 if (pingOut > pingMaxOut)
                 {
                     lostConnection = true;
-                    pingEx = new StanMaxPingsException();
                 }
                 else
                 {
@@ -369,7 +367,7 @@ namespace STAN.Client
 
             if (lostConnection)
             {
-                closeDueToPing(pingEx);
+                closeDueToPing(new StanMaxPingsException());
                 return;
             }
             
@@ -384,6 +382,7 @@ namespace STAN.Client
             {
                 closeDueToPing(ex);
             }
+            catch { /* ignore other publish exceptions */ }
         }
 
         private void closeDueToPing(Exception ex)

--- a/src/Tests/IntegrationTests/BasicTests.cs
+++ b/src/Tests/IntegrationTests/BasicTests.cs
@@ -784,6 +784,24 @@ namespace IntegrationTests
         }
 
         [Fact]
+        public void TestCloseWhileReconnecting()
+        {
+            using var s = Context.StartStreamingServerWithEmbedded(Context.DefaultServer);
+            using var c = Context.GetStanConnection(Context.DefaultServer);
+
+            s.Shutdown();
+
+            // wait until attempting to reconnect
+            while (c.NATSConnection.IsReconnecting() == false)
+            {
+                Thread.Sleep(100);
+            }
+
+            // ensure close does not throw (which would fail the test)
+            c.Close();
+        }
+
+        [Fact]
         public void TestDoubleClose()
         {
             using (Context.StartStreamingServerWithEmbedded(Context.DefaultServer))

--- a/src/Tests/IntegrationTests/BasicTests.cs
+++ b/src/Tests/IntegrationTests/BasicTests.cs
@@ -786,14 +786,17 @@ namespace IntegrationTests
         [Fact]
         public void TestCloseWhileReconnecting()
         {
+            int attempts = 50;
+
             using var s = Context.StartStreamingServerWithEmbedded(Context.DefaultServer);
             using var c = Context.GetStanConnection(Context.DefaultServer);
 
             s.Shutdown();
 
             // wait until attempting to reconnect
-            while (c.NATSConnection.IsReconnecting() == false)
+            for (int i = 1; i <= attempts && c.NATSConnection.IsReconnecting() == false; i++)
             {
+                Assert.False(i == attempts);
                 Thread.Sleep(100);
             }
 


### PR DESCRIPTION
If close was called while reconnecting, an exception could be thrown.  This was breaking backward compatibility.  Gracefully close the client if `StanConnection.Close()` is called while reconnecting.

Also remove the check for buffering in assigning NatsConn for backward compatibility as well.
