### PR TITLE
Use a soft flush to reduce latency

### DIFF
--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -624,13 +624,9 @@ namespace STAN.Client
                 nc.Publish(subj, localAckSubject, b);
 
                 // Flush to reduce latency.
-                // 
-                // TODO:  Add a soft (non-ping) flush to NATS.net 
-                // for this type of situation.  Only flush in 
-                // blocking publish calls.
                 if (handler == null)
                 {
-                    nc.Flush();
+                    nc.FlushBuffer();
                 }
             }
             catch


### PR DESCRIPTION
Use `Connection.FlushBuffer()` over `Connection.Flush()` to reduce overhead and latency.

Signed-off-by: Colin Sullivan <colin@synadia.com>