### PR TITLE
Resolve deadlocks seen during rapid publishes #175

### DIFF
--- a/STAN.CLIENT/BlockingChannel.cs
+++ b/STAN.CLIENT/BlockingChannel.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace STAN.Client
@@ -40,7 +41,8 @@ namespace STAN.Client
             {
                 lock (dLock)
                 {
-                    return d.Keys;
+                    // Take a snapshot under the lock
+                    return d.Keys.ToArray();
                 }
             }
         }

--- a/STAN.CLIENT/BlockingChannel.cs
+++ b/STAN.CLIENT/BlockingChannel.cs
@@ -47,14 +47,27 @@ namespace STAN.Client
             }
         }
 
-        internal void waitForSpace()
+        /// <summary>
+        /// Wait for space to become available within a given
+        /// amount of time.
+        /// </summary>
+        /// <param name="millisecondsTimeout">The number of milliseconds
+        /// to wait for space to become available.</param>
+        /// <returns><see langword="true"/> if there is capacity
+        /// available, otherwise <see langword="false"/>.</returns>
+        internal bool TryWaitForSpace(int millisecondsTimeout)
         {
             lock (addLock)
             {
                 while (isAtCapacity())
                 {
-                    Monitor.Wait(addLock);
+                    if (!Monitor.Wait(addLock, millisecondsTimeout))
+                    {
+                        return false;
+                    }
                 }
+
+                return true;
             }
         }
 

--- a/STAN.CLIENT/BlockingChannel.cs
+++ b/STAN.CLIENT/BlockingChannel.cs
@@ -77,31 +77,28 @@ namespace STAN.Client
 
             lock (dLock)
             {
-                if (!finished)
+                // check and wait if empty and not finished
+                while (!finished && d.Count == 0)
                 {
-                    // check and wait if empty
-                    while (d.Count == 0)
+                    if (timeout < 0)
                     {
-                        if (timeout < 0)
+                        Monitor.Wait(dLock);
+                    }
+                    else
+                    {
+                        if (timeout > 0)
                         {
-                            Monitor.Wait(dLock);
-                        }
-                        else
-                        {
-                            if (timeout > 0)
+                            if (Monitor.Wait(dLock, timeout) == false)
                             {
-                                if (Monitor.Wait(dLock, timeout) == false)
-                                {
-                                    throw new Exception("timeout");
-                                }
+                                throw new Exception("timeout");
                             }
                         }
                     }
+                }
 
-                    if (!finished)
-                    {
-                        rv = d.TryGetValue(key, out value);
-                    }
+                if (!finished)
+                {
+                    rv = d.TryGetValue(key, out value);
                 }
 
                 if (rv)

--- a/STAN.CLIENT/StanConnection.cs
+++ b/STAN.CLIENT/StanConnection.cs
@@ -155,8 +155,8 @@ namespace STAN.Client
         private int pingOut;
         private int pingMaxOut;
 
-        private IDictionary<string, AsyncSubscription> subMap = new Dictionary<string, AsyncSubscription>();
-        private BlockingDictionary<string, PublishAck> pubAckMap;
+        private readonly IDictionary<string, AsyncSubscription> subMap = new Dictionary<string, AsyncSubscription>();
+        private readonly BlockingDictionary<string, PublishAck> pubAckMap;
 
         internal ProtocolSerializer ps = new ProtocolSerializer();
 
@@ -500,12 +500,7 @@ namespace STAN.Client
 
         internal PublishAck removeAck(string guid)
         {
-            PublishAck a;
-
-            lock (mu)
-            {
-                pubAckMap.Remove(guid, out a, 0);
-            }
+            pubAckMap.Remove(guid, out PublishAck a, 0);
 
             return a;
         }


### PR DESCRIPTION
This PR attempts to resolve deadlocks seen during rapid, small publishes detailed in #175.

The root fix for the issue seen is to move code which accesses `addLock` within `BlockingDictionary` out from underneath `dLock` (09f6caa). On its own, this appears to resolve the deadlocks seen. Additionally, because `pubAckMap` never has its instance changed, the requirement for `StanConnection.mu` to be held goes away (89150f2). However, removing this lock requires that snapshot semantics be used when accessing `pubAckMap.Keys` (aaa05f8).

During testing, other deadlocks became apparent. If I increased the number of threads publishing and introduced random delays in some of the threads, if the STAN sever died unexpectedly there were deadlocks waiting for `pubAckMap` to become non-empty after ping timeouts (f52eeec). By introducing a timeout waiting for space in `pubAckMap` equal to the ping interval (38091ce), the STAN client became much more responsive to unexpected connection failures and did not deadlock under heavy load with inappropriate options (`MaxPubAcksInFlight == 3`).