### PR TITLE
Resolve deadlock when publishing small messages rapidly #175

### DIFF
--- a/src/STAN.Client/BlockingChannel.cs
+++ b/src/STAN.Client/BlockingChannel.cs
@@ -48,14 +48,19 @@ namespace STAN.Client
             }
         }
 
-        internal void waitForSpace()
+        internal bool TryWaitForSpace(int millisecondsTimeout)
         {
             lock (addLock)
             {
                 while (isAtCapacity())
                 {
-                    Monitor.Wait(addLock);
+                    if (!Monitor.Wait(addLock, millisecondsTimeout))
+                    {
+                        return false;
+                    }
                 }
+
+                return true;
             }
         }
 

--- a/src/STAN.Client/BlockingChannel.cs
+++ b/src/STAN.Client/BlockingChannel.cs
@@ -48,19 +48,14 @@ namespace STAN.Client
             }
         }
 
-        internal bool TryWaitForSpace(int millisecondsTimeout)
+        internal void TryWaitForSpace(int millisecondsTimeout)
         {
             lock (addLock)
             {
-                while (isAtCapacity())
+                if (isAtCapacity())
                 {
-                    if (!Monitor.Wait(addLock, millisecondsTimeout))
-                    {
-                        return false;
-                    }
+                    _ = Monitor.Wait(addLock, millisecondsTimeout);
                 }
-
-                return true;
             }
         }
 

--- a/src/STAN.Client/BlockingChannel.cs
+++ b/src/STAN.Client/BlockingChannel.cs
@@ -21,10 +21,10 @@ namespace STAN.Client
     // This dictionary class is a capacity bound, threadsafe, dictionary.
     internal sealed class BlockingDictionary<TKey, TValue>
     {
-        IDictionary<TKey, TValue> d = new Dictionary<TKey, TValue>();
-        Object dLock = new Object();
-        Object addLock = new Object();
-        long maxSize = 1024;
+        private readonly IDictionary<TKey, TValue> d = new Dictionary<TKey, TValue>();
+        private readonly Object dLock = new Object();
+        private readonly Object addLock = new Object();
+        private long maxSize = 1024;
 
         private bool isAtCapacity()
         {
@@ -83,14 +83,14 @@ namespace STAN.Client
                 {
                     wasAtCapacity = d.Count >= maxSize;
                     d.Remove(key);
+                }
+            }
 
-                    if (wasAtCapacity)
-                    {
-                        lock (addLock)
-                        {
-                            Monitor.Pulse(addLock);
-                        }
-                    }
+            if (wasAtCapacity)
+            {
+                lock (addLock)
+                {
+                    Monitor.Pulse(addLock);
                 }
             }
 

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -158,8 +158,8 @@ namespace STAN.Client
         private int pingOut;
         private int pingMaxOut;
 
-        private IDictionary<string, AsyncSubscription> subMap = new Dictionary<string, AsyncSubscription>();
-        private BlockingDictionary<string, PublishAck> pubAckMap;
+        private readonly IDictionary<string, AsyncSubscription> subMap = new Dictionary<string, AsyncSubscription>();
+        private readonly BlockingDictionary<string, PublishAck> pubAckMap;
 
         internal ProtocolSerializer ps = new ProtocolSerializer();
 
@@ -502,12 +502,9 @@ namespace STAN.Client
 
         internal PublishAck removeAck(string guid)
         {
-            PublishAck a;
-
-            lock (mu)
+            if (pubAckMap.Remove(guid, out PublishAck a))
             {
-                if (pubAckMap.Remove(guid, out a))
-                    return a;
+                return a;
             }
 
             return null;

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -604,7 +604,7 @@ namespace STAN.Client
                     // Wait for space outside of the lock so 
                     // acks can be removed and other executive
                     // functions can continue
-                    _ = pubAckMap.TryWaitForSpace(pingInterval);
+                    pubAckMap.TryWaitForSpace(pingInterval);
                     Monitor.Enter(mu);
 
                     if (nc == null || nc.IsClosed())

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -581,7 +581,6 @@ namespace STAN.Client
         internal PublishAck publish(string subject, byte[] data, EventHandler<StanAckHandlerArgs> handler)
         {
             string localAckSubject = null;
-            long localAckTimeout = 0;
 
             string subj = this.pubPrefix + "." + subject;
             string guidValue = newGUID();
@@ -590,31 +589,32 @@ namespace STAN.Client
 
             lock (mu)
             {
-                if (nc == null)
+                if (nc == null || nc.IsClosed())
                     throw new StanConnectionClosedException();
 
                 if (nc.IsReconnecting())
                     throw new StanConnectionException("The NATS connection is reconnecting");
 
                 a = new PublishAck(this, guidValue, handler, opts.PubAckWait);
+
+                int pingInterval = opts.PingInterval;
                 while (!pubAckMap.TryAdd(guidValue, a))
                 {
-                    var bd = pubAckMap;
-
                     Monitor.Exit(mu);
                     // Wait for space outside of the lock so 
-                    // acks can be removed.
-                    bd.waitForSpace();
+                    // acks can be removed and other executive
+                    // functions can continue
+                    _ = pubAckMap.TryWaitForSpace(pingInterval);
                     Monitor.Enter(mu);
 
-                    if (nc == null)
-                    {
+                    if (nc == null || nc.IsClosed())
                         throw new StanConnectionClosedException();
-                    }
+
+                    if (nc.IsReconnecting())
+                        throw new StanConnectionException("The NATS connection is reconnecting");
                 }
 
                 localAckSubject = ackSubject;
-                localAckTimeout = opts.ackTimeout;
             }
 
             try

--- a/src/Tests/IntegrationTests/BasicTests.cs
+++ b/src/Tests/IntegrationTests/BasicTests.cs
@@ -1661,7 +1661,7 @@ namespace IntegrationTests
             }
         }
 
-        [Fact(Skip = "HANGS SOMETIMES")]
+        [Fact]
         public void TestMaxPubAckInflight()
         {
             using (Context.StartStreamingServerWithEmbedded(Context.DefaultServer))


### PR DESCRIPTION
This resolves deadlocks seen when publishing small messages rapidly as detailed in #175.

The primary resolution is to not hold `addLock` while also holding `dLock` within `BlockingDictionary.Remove` (3d19c4b).

A second observation is that `pubAckMap` can be made `readonly`, removing the need for an additional lock wrapping `pubAckMap.Remove` when processing acks (384fb15).

The last fix is to avoid deadlocks when the connection is lost unexpectedly, seen when interleaving very rapid publishing and publishing slowed with random intervals, by only waiting up to the ping interval before retrying (6d7cdb2).