### PR TITLE
Add a configurable timeout to protocol messages

### DIFF
--- a/src/STAN.Client/AsyncSubscription.cs
+++ b/src/STAN.Client/AsyncSubscription.cs
@@ -119,7 +119,7 @@ namespace STAN.Client
                 byte[] b = ProtocolSerializer.marshal(sr);
 
                 // TODO:  Configure request timeout?
-                Msg m = sc.NATSConnection.Request(subRequestSubject, b, 2000);
+                Msg m = sc.NATSConnection.Request(subRequestSubject, b, sc.opts.ConnectTimeout);
 
                 SubscriptionResponse r = new SubscriptionResponse();
                 ProtocolSerializer.unmarshal(m.Data, r);

--- a/src/STAN.Client/AsyncSubscription.cs
+++ b/src/STAN.Client/AsyncSubscription.cs
@@ -118,7 +118,6 @@ namespace STAN.Client
 
                 byte[] b = ProtocolSerializer.marshal(sr);
 
-                // TODO:  Configure request timeout?
                 Msg m = sc.NATSConnection.Request(subRequestSubject, b, sc.opts.ConnectTimeout);
 
                 SubscriptionResponse r = new SubscriptionResponse();

--- a/src/STAN.Client/Options.cs
+++ b/src/STAN.Client/Options.cs
@@ -86,8 +86,8 @@ namespace STAN.Client
         }
 
         /// <summary>
-        /// ConnectTimeout is an Option to set the timeout for establishing a connection
-        /// in milliseconds.
+        // ConnectTimeout is the timeout in milliseconds for the initial Connect. This value is also
+        // used for some of the internal request/replies with the cluster.  The default is 2000 ms.
         /// </summary>
         public int ConnectTimeout
         {

--- a/src/STAN.Client/Options.cs
+++ b/src/STAN.Client/Options.cs
@@ -86,8 +86,8 @@ namespace STAN.Client
         }
 
         /// <summary>
-        // ConnectTimeout is the timeout in milliseconds for the initial Connect. This value is also
-        // used for some of the internal request/replies with the cluster.  The default is 2000 ms.
+        /// ConnectTimeout is the timeout in milliseconds for the initial Connect. This value is also
+        /// used for some of the internal request timeouts with the cluster.  The default is 2000 ms.
         /// </summary>
         public int ConnectTimeout
         {

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -163,7 +163,8 @@ namespace STAN.Client
 
         internal ProtocolSerializer ps = new ProtocolSerializer();
 
-        internal StanOptions opts = null;
+        // Options are set in the constructor.
+        internal readonly StanOptions opts;
 
         private IConnection nc;
         private bool ncOwned = false;

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -163,7 +163,7 @@ namespace STAN.Client
 
         internal ProtocolSerializer ps = new ProtocolSerializer();
 
-        private StanOptions opts = null;
+        internal StanOptions opts = null;
 
         private IConnection nc;
         private bool ncOwned = false;
@@ -712,7 +712,7 @@ namespace STAN.Client
             };
             byte[] b = ProtocolSerializer.marshal(usr);
 
-            var r = lnc.Request(requestSubject, b, 2000);
+            var r = lnc.Request(requestSubject, b, opts.connectTimeout);
             SubscriptionResponse sr = new SubscriptionResponse();
             ProtocolSerializer.unmarshal(r.Data, sr);
             if (!string.IsNullOrEmpty(sr.Error))
@@ -783,7 +783,7 @@ namespace STAN.Client
                 {
                     if (closeRequests != null)
                     {
-                        reply = nc.Request(closeRequests, ProtocolSerializer.marshal(req));
+                        reply = nc.Request(closeRequests, ProtocolSerializer.marshal(req), opts.connectTimeout);
                     }
                 }
                 catch (StanBadSubscriptionException)


### PR DESCRIPTION
Ensure all protocol messages have the configurable timeout.  Piggy back on the connect timeout like golang does.

Resolves #185

Signed-off-by: Colin Sullivan <colin@synadia.com>