### PR TITLE
No Responders and Prepare for Release

### DIFF
--- a/doc/DoxyFile.STAN.Client
+++ b/doc/DoxyFile.STAN.Client
@@ -38,7 +38,7 @@ PROJECT_NAME           = "NATS Streaming .NET Client"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.2.1
+PROJECT_NUMBER         = 0.3.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/STAN.Client/STAN.Client.csproj
+++ b/src/STAN.Client/STAN.Client.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.10.0" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.10.0" PrivateAssets="All" />
-    <PackageReference Include="NATS.Client" Version="0.10.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.13.0" PrivateAssets="All" />
+    <PackageReference Include="NATS.Client" Version="0.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/STAN.Client/StanConnection.cs
+++ b/src/STAN.Client/StanConnection.cs
@@ -149,7 +149,11 @@ namespace STAN.Client
         private ISubscription pingSubscription = null;
 
         private readonly object pingLock = new object();
+
+#pragma warning disable 0618
         private readonly NUID pubNUID = new NUID();
+#pragma warning restore 0618
+
         private Timer pingTimer;
         private readonly byte[] pingBytes;
         private readonly string pingRequests;
@@ -576,7 +580,9 @@ namespace STAN.Client
 
         static public string newGUID()
         {
+#pragma warning disable 0618
             return NUID.NextGlobal;
+#pragma warning restore 0618
         }
 
         public void Publish(string subject, byte[] data)

--- a/src/Samples/RxSample/RxSample.csproj
+++ b/src/Samples/RxSample/RxSample.csproj
@@ -13,4 +13,7 @@
     <ProjectReference Include="..\..\STAN.Client\STAN.Client.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NATS.Client" Version="0.11.0" />
+  </ItemGroup>
 </Project>

--- a/src/Samples/StanPub/StanPub.csproj
+++ b/src/Samples/StanPub/StanPub.csproj
@@ -12,4 +12,7 @@
     <ProjectReference Include="..\..\STAN.Client\STAN.Client.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NATS.Client" Version="0.11.0" />
+  </ItemGroup>
 </Project>

--- a/src/Samples/StanSub/StanSub.csproj
+++ b/src/Samples/StanSub/StanSub.csproj
@@ -12,4 +12,7 @@
     <ProjectReference Include="..\..\STAN.Client\STAN.Client.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NATS.Client" Version="0.11.0" />
+  </ItemGroup>
 </Project>

--- a/src/Tests/IntegrationTests/IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/IntegrationTests.csproj
@@ -9,9 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200921-01" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+<PrivateAssets>all</PrivateAssets>
+</PackageReference>
+    <PackageReference Include="NATS.Client" Version="0.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/IntegrationTests/PingTests.cs
+++ b/src/Tests/IntegrationTests/PingTests.cs
@@ -62,6 +62,11 @@ namespace IntegrationTests
                 {
                     nc.SubscribeAsync(StanConsts.DefaultDiscoverPrefix + "." + Context.ClusterId + ".pings", (obj, args) =>
                     {
+                        if (args.Message.Data.Length == 0)
+                        {
+                            return;
+                        }
+
                         count++;
                         if (count > StanConsts.DefaultPingMaxOut)
                         {
@@ -99,7 +104,7 @@ namespace IntegrationTests
                     AutoResetEvent ev = new AutoResetEvent(false);
 
                     var so = Context.GetStanTestOptions(Context.Server1);
-                    so.PingInterval = 200;
+                    so.PingInterval = 100;
                     so.PingMaxOutstanding = 3;
                     so.ConnectionLostEventHandler = (obj, args) =>
                     {
@@ -108,8 +113,9 @@ namespace IntegrationTests
 
                     using (var sc = Context.GetStanConnection(so))
                     {
+                        sc.NATSConnection.FlushBuffer();
                         nss.Shutdown();
-                        Assert.True(ev.WaitOne(20000));
+                        Assert.True(ev.WaitOne(2000));
                     }
                 }
             }
@@ -124,10 +130,6 @@ namespace IntegrationTests
                 using (var nss = Context.StartStreamingServerWithExternal(Context.Server1))
                 {
                     var ev = new AutoResetEvent(false);
-                    //var so = StanOptions.GetDefaultOptions();
-                    //so.PingInterval = 50;
-                    //so.PingMaxOutstanding = 10;
-                    //so.PubAckWait = 100;
 
                     using (var sc = Context.GetStanConnection(Context.Server1))
                     {

--- a/src/Tests/UnitTests/UnitTests.csproj
+++ b/src/Tests/UnitTests/UnitTests.csproj
@@ -9,9 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+<PrivateAssets>all</PrivateAssets>
+</PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NATS.Client" Version="0.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As part of release testing against the NATS .NET client 0.11.0, I found an issue with no-responders.

* Handle No-Responders
* Bump doc version
* Bump dependency versions

