### PR TITLE
Bump Google.Protobuf.Tools from 3.13.0 to 3.15.0

### DIFF
--- a/src/STAN.Client/STAN.Client.csproj
+++ b/src/STAN.Client/STAN.Client.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.13.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.15.0" PrivateAssets="All" />
     <PackageReference Include="NATS.Client" Version="0.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
To be consistent with https://github.com/nats-io/stan.net/pull/203.

See a related conversation at https://github.com/nats-io/stan.net/issues/204.

